### PR TITLE
Allow direct access when using a registered process

### DIFF
--- a/src/ets_lru.erl
+++ b/src/ets_lru.erl
@@ -85,6 +85,13 @@ match(LRU, KeySpec, ValueSpec) ->
 %% capturing placeholders will be aliased between the key and value
 %% parts.
 -spec match_object(atom() | pid(), term(), term()) -> [any()].
+match_object(Name, KeySpec, ValueSpec) when is_atom(Name) ->
+    Pattern = #entry{key=KeySpec, val=ValueSpec, _='_'},
+    Entries = ets:match_object(obj_table(Name), Pattern),
+    lists:map(fun(#entry{key=Key,val=Val}) ->
+        gen_server:cast(Name, {accessed, Key}),
+        Val
+    end, Entries);
 match_object(LRU, KeySpec, ValueSpec) ->
     gen_server:call(LRU, {match_object, KeySpec, ValueSpec}).
 

--- a/test/06-match.t
+++ b/test/06-match.t
@@ -5,7 +5,7 @@
 main([]) ->
     code:add_pathz("test"),
     code:add_pathz("ebin"),
-    tutil:run(6, fun() -> test() end).
+    tutil:run(7, fun() -> test() end).
 
 test() ->
     ?WITH_LRU(test_match_zero_values),
@@ -35,7 +35,10 @@ test_match_zero_objects(LRU) ->
 
 test_match_one_object(LRU) ->
     ets_lru:insert(LRU, ans, 42),
-    etap:is(ets_lru:match_object(LRU, ans, '$1'), [42], "Single match_object").
+    ViaRegistered = ets_lru:match_object(test_lru, ans, '$1'),
+    etap:is(ViaRegistered, [42], "Single match_object (registered)"),
+    ViaPid = ets_lru:match_object(LRU, ans, '$1'),
+    etap:is(ViaPid, [42], "Single match_object (pid)").
 
 test_match_many_objects(LRU) ->
     ets_lru:insert(LRU, {color, blue}, a),


### PR DESCRIPTION
The match_object API currently takes both atoms and pids.
This change allows the atom case to skip a synchronous call
to the gen_server state. The old path remains to allow pids
to continue to work through the old call path since it
can't easily infer the lru objects table name.

BugzId: 26105
